### PR TITLE
Remove deprecated workaround

### DIFF
--- a/Bundled Node/run.sh
+++ b/Bundled Node/run.sh
@@ -279,8 +279,6 @@ then
 else
     if [ "$DIST_OS" = "macosx" ] # Some osx weirdness, someone please check that this still works
     then
-	# We don't have a binary for OS/X on 64-bit at present.
-	DIST_BIT="32"
         WRAPPER_TEST_CMD="$WRAPPER_CMD-$DIST_OS-universal-$DIST_BIT"
         if [ -x "$WRAPPER_TEST_CMD" ]
         then


### PR DESCRIPTION
It seems we currently have a 64 bit binary for Mac OS. Same as: https://github.com/freenet/java_installer/pull/18